### PR TITLE
ensure that authorization token is passed in uri options if present

### DIFF
--- a/lib/quandl/request.rb
+++ b/lib/quandl/request.rb
@@ -9,7 +9,7 @@ module Quandl
     def initialize(base, params)
       path = [Quandl.configuration.api_version, base]
       if Quandl.configuration.auth_token
-        params[:auth_token] = Quandl.configuration.auth_token
+        params[:options][:auth_token] = Quandl.configuration.auth_token
       end
       [:source, :table].each do |param|
         path << params[param] if params[param]


### PR DESCRIPTION
Hey Kash,

In using the gem today, I ran into a 429 Too Many Requests error, way before I should have.

After doing some sleuthing, I discovered the problem. The auth_token is getting passed to the params in this file, however it's not getting added to the URI because it sits outside of the options hash, which is inside the params hash.

i.e.

params = {dataset: 'CME/HOZ2014', options: { sort_order: 'asc' }, auth_token: 'some_token' }

when it should be

params = {dataset: 'CME/HOZ2014', options: { sort_order: 'asc', auth_token: 'some_token' } }

This commit fixes the problem, I've tested locally, it works splendidly for me now :smile: 

Will
