### PR TITLE
switch to https

### DIFF
--- a/lib/quandl/request.rb
+++ b/lib/quandl/request.rb
@@ -1,7 +1,7 @@
 require 'open-uri'
 
 module Quandl
-  API_URI = 'http://www.quandl.com/api/'
+  API_URI = 'https://www.quandl.com/api/'
 
   class Request
     attr_accessor :uri


### PR DESCRIPTION
Please release a new version of your gem with this change applied as Quandl will disable HTTP access to their API on May 15th.
